### PR TITLE
Fixed Event Creation bug

### DIFF
--- a/Jackpot/app/src/main/java/com/example/jackpot/ui/event_creation/EventCreationFragment.java
+++ b/Jackpot/app/src/main/java/com/example/jackpot/ui/event_creation/EventCreationFragment.java
@@ -323,7 +323,8 @@ public class EventCreationFragment extends Fragment {
         // Numeric fields as numbers
         eventDoc.put("price", priceVal);
         eventDoc.put("capacity", capacityVal);
-        if (waitLimitVal != null) eventDoc.put("waitingListLimit", waitLimitVal);
+        if (waitLimitVal == null)  {waitLimitVal = 0;}
+        eventDoc.put("waitingListLimit", waitLimitVal);
 
         eventDoc.put("geoLocation", geoLocation);
         eventDoc.put("qrCode", qrCode);


### PR DESCRIPTION
Fixed Eventcreatbug. NOTE: If waitingListLimit is left empty, the variable capacity is set to 0; there must be logic to prevent a situatioon where nobody can join a waitinglist at all.